### PR TITLE
Added .vimrc file with an autocmd for use in git bash

### DIFF
--- a/REMOVE_THIS.vimrc
+++ b/REMOVE_THIS.vimrc
@@ -1,0 +1,3 @@
+setglobal fileencoding=utf-8
+setglobal fileencodings=ucs-bom,utf-8
+autocmd VimEnter * set fileformat=dos


### PR DESCRIPTION
This includes an autocommand that will set the file format to "dos" as soon as Vim starts. The result is that files will use CRLF instead of the Unix version with only LF for newlines (or Line Feed, if you will).

This was necessary because what should have been the obvious first choice - setting the file format directly in the config - simply did not work. This might have something to do with the fact that I generally run vim in the Git Bash console, but I'm not sure. In any case, the added command will run whenver vim opens, and should work for all files now, which is what I do want when working on Windows.